### PR TITLE
Stop generating deprecated package json for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ scaffolding
 -   [Contributors](https://github.com/flarebyte/baldrick-elm/graphs/contributors)
 -   [Dependencies](https://github.com/flarebyte/baldrick-elm/network/dependencies)
 
+## Usage
+
+To generate basic structure files:
+
+```bash
+baldrick-elm generate -f lib -ga 'mygithub' -ch 'MyCompany' -cy 2018 -l BSD3
+```
+
+Afterwards, you will need to run:
+
+```bash
+make norm
+```
+
 ## Installation
 
 This package is [ESM

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "devDependencies": {
     "baldrick-dev-ts": "^0.15.0",
     "baldrick-tsconfig-es2020": "^0.9.0",
-    "ts-node": "^10.8.1",
+    "ts-node": "10.8.2",
     "typescript": "^4.7.4"
   },
   "peerDependencies": {}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "Elm",
     "Scaffolding"
   ],
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": {
     "name": "Olivier Huin",
     "url": "https://github.com/olih"

--- a/script/cli-test-expect.txt
+++ b/script/cli-test-expect.txt
@@ -6,7 +6,6 @@
 .gitignore
 .vscode/baldrick.code-snippets
 .vscode/settings.json
-tests/elm-package.json
 script/data/project.json
 script/schema/project.schema.json
 CODE_OF_CONDUCT.md

--- a/src/dev-tasks.ts
+++ b/src/dev-tasks.ts
@@ -347,7 +347,6 @@ const whiskerNormCmd = (project: CoreProject): MdCommand => {
       'mkdir -p script/schema',
       'mkdir -p script/template',
       'test -f "elm.json" || npx baldrick-whisker@latest object elm.json github:flarebyte:baldrick-reserve:data/elm/src-elm.json',
-      'test -f "tests/elm-package.json" || npx baldrick-whisker@latest object tests/elm-package.json github:flarebyte:baldrick-reserve:data/elm/test-elm.json',
       'test -f ".vscode/settings.json" || npx baldrick-whisker@latest object .vscode/settings.json github:flarebyte:baldrick-reserve:data/elm/vscode-settings.json',
       'test -f "script/data/project.json" || npx baldrick-whisker@latest object script/data/project.json github:flarebyte:baldrick-reserve:data/elm/project.json',
       'npx baldrick-whisker@latest object --no-ext .vscode/baldrick.code-snippets.json github:flarebyte:baldrick-reserve:data/elm/snippet.yaml',

--- a/src/markdown-readme.ts
+++ b/src/markdown-readme.ts
@@ -45,10 +45,8 @@ const docAndLinks = (core: CoreProject): MdSection => ({
   body: [
     '* [Code Maintenance](MAINTENANCE.md)',
     '* [Code Of Conduct](CODE_OF_CONDUCT.md)',
-    `* [Api for ${core.name}](API.md)`,
     '* [Contributing](CONTRIBUTING.md)',
     '* [Glossary](GLOSSARY.md)',
-    '* [Diagram for the code base](INTERNAL.md)',
     '* [Vocabulary used in the code base](CODE_VOCABULARY.md)',
     '* [Architectural Decision Records](DECISIONS.md)',
     `* [Contributors](https://github.com/${core.githubAccount}/${core.name}/graphs/contributors)`,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.7.0';
+export const version = '0.8.0';

--- a/test/__snapshots__/markdown-maintenance.test.ts.snap
+++ b/test/__snapshots__/markdown-maintenance.test.ts.snap
@@ -514,7 +514,6 @@ Array [
       "mkdir -p script/schema",
       "mkdir -p script/template",
       "test -f \\"elm.json\\" || npx baldrick-whisker@latest object elm.json github:flarebyte:baldrick-reserve:data/elm/src-elm.json",
-      "test -f \\"tests/elm-package.json\\" || npx baldrick-whisker@latest object tests/elm-package.json github:flarebyte:baldrick-reserve:data/elm/test-elm.json",
       "test -f \\".vscode/settings.json\\" || npx baldrick-whisker@latest object .vscode/settings.json github:flarebyte:baldrick-reserve:data/elm/vscode-settings.json",
       "test -f \\"script/data/project.json\\" || npx baldrick-whisker@latest object script/data/project.json github:flarebyte:baldrick-reserve:data/elm/project.json",
       "npx baldrick-whisker@latest object --no-ext .vscode/baldrick.code-snippets.json github:flarebyte:baldrick-reserve:data/elm/snippet.yaml",

--- a/test/__snapshots__/markdown-readme.test.ts.snap
+++ b/test/__snapshots__/markdown-readme.test.ts.snap
@@ -42,10 +42,8 @@ yarn add scratchbook
 
 * [Code Maintenance](MAINTENANCE.md)
 * [Code Of Conduct](CODE_OF_CONDUCT.md)
-* [Api for project123](API.md)
 * [Contributing](CONTRIBUTING.md)
 * [Glossary](GLOSSARY.md)
-* [Diagram for the code base](INTERNAL.md)
 * [Vocabulary used in the code base](CODE_VOCABULARY.md)
 * [Architectural Decision Records](DECISIONS.md)
 * [Contributors](https://github.com/mycompany/project123/graphs/contributors)

--- a/test/commit-message.test.ts
+++ b/test/commit-message.test.ts
@@ -4,7 +4,7 @@ describe('commit-message', () => {
   it('should provide a commit message', () => {
     const actual = commitMessage();
     expect(actual).toMatchInlineSnapshot(`
-      "Normalize the code structure with baldrick-elm version 0.7.0
+      "Normalize the code structure with baldrick-elm version 0.8.0
       See https://github.com/flarebyte/baldrick-elm/releases"
     `);
   });

--- a/test/makefile.test.ts
+++ b/test/makefile.test.ts
@@ -111,7 +111,6 @@ describe('makefile', () => {
       	mkdir -p script/schema
       	mkdir -p script/template
       	test -f \\"elm.json\\" || npx baldrick-whisker@latest object elm.json github:flarebyte:baldrick-reserve:data/elm/src-elm.json
-      	test -f \\"tests/elm-package.json\\" || npx baldrick-whisker@latest object tests/elm-package.json github:flarebyte:baldrick-reserve:data/elm/test-elm.json
       	test -f \\".vscode/settings.json\\" || npx baldrick-whisker@latest object .vscode/settings.json github:flarebyte:baldrick-reserve:data/elm/vscode-settings.json
       	test -f \\"script/data/project.json\\" || npx baldrick-whisker@latest object script/data/project.json github:flarebyte:baldrick-reserve:data/elm/project.json
       	npx baldrick-whisker@latest object --no-ext .vscode/baldrick.code-snippets.json github:flarebyte:baldrick-reserve:data/elm/snippet.yaml

--- a/yarn.lock
+++ b/yarn.lock
@@ -5019,10 +5019,10 @@ ts-jest@^27.1.2:
     semver "7.x"
     yargs-parser "20.x"
 
-ts-node@^10.8.1:
-  version "10.8.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.8.1.tgz#ea2bd3459011b52699d7e88daa55a45a1af4f066"
-  integrity sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==
+ts-node@10.8.2:
+  version "10.8.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.8.2.tgz#3185b75228cef116bf82ffe8762594f54b2a23f2"
+  integrity sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.0"
     "@tsconfig/node10" "^1.0.7"


### PR DESCRIPTION
# Summary of the change

- remove generation of elm test json
- Update readme to remove ts only links
- Improve readme

## Code check

-   [x] `yarn ready` does not show any concerning issues
-   [x] the project can be built
-   [x] the documentation has been updated
-   [x] the version has been updated in `package.json`

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)

-   [ ] New feature (non-breaking change which adds functionality)

-   [x] Breaking change (fix or feature that would cause existing
    functionality to not work as expected)

## Motivation and context

-   [ ] improve user experience
-   [x] improve consistency
-   [ ] improve security
-   [ ] improve documentation
-   [ ] reduce risk for unfamiliar tasks
-   [ ] automate repetitive tasks

## How Has This Been Tested

-   [x] Unit tests
-   [x] Manual tests
